### PR TITLE
docs: add badges and table of contents for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 https://github.com/asanchezyali/talking-avatar-with-ai/assets/29262782/da316db9-6dd1-4475-9fe5-39dafbeb3cc4
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/asanchezyali/talking-avatar-with-ai/blob/main/LICENSE)
+[![Python](https://img.shields.io/badge/Python-3.10%2B-blue?logo=python)](https://python.org)
+[![Stars](https://img.shields.io/github/stars/asanchezyali/talking-avatar-with-ai?style=social)](https://github.com/asanchezyali/talking-avatar-with-ai)
+[![Last Commit](https://img.shields.io/github/last-commit/asanchezyali/talking-avatar-with-ai)](https://github.com/asanchezyali/talking-avatar-with-ai/commits/main)
+
+## Table of Contents
+
+- [Overview](#digital-human)
+- [How it Operates](#how-it-operates)
+- [Getting Started](#getting-started)
+  - [Requirements](#requirements)
+  - [Installation](#installation)
+- [References](#references)
+
 ## Digital Human
 
 This project is a digital human that can talk and listen to you. It uses OpenAI's GPT-3 to generate responses, OpenAI's


### PR DESCRIPTION
## What this PR does

Adds two small documentation improvements to the README:

- **Badges** (license, Python version, stars, last commit) at the top — so visitors can instantly see project status and compatibility at a glance
- **Table of Contents** — for easier navigation, especially helpful as the README grows

## Why

These are pure-documentation changes with zero code risk. Badges improve discoverability in GitHub search and signal active maintenance to potential contributors. The TOC reduces friction for new users trying to find the setup steps quickly.

---
*I came across this project while exploring realtime avatar pipelines — really solid integration of Whisper + ElevenLabs + lip sync. If you're ever looking for a hosted realtime avatar streaming layer to pair with setups like this, [spatialwalk's livetime avatar](https://github.com/spatialwalk) is worth a look.*